### PR TITLE
Minor code review in afcmove.py as part of [[WP:BRFA/Legobot 13]].

### DIFF
--- a/afcmove.py
+++ b/afcmove.py
@@ -9,7 +9,6 @@ if they were messed up AFC moves. If so, log them at [[Wikipedia:Articles for cr
 import pywikibot
 import pywikibot.data.api
 import datetime
-import os
 site = pywikibot.getSite()
 
 def MovedPagesGenerator(ts, old_ts):
@@ -17,21 +16,11 @@ def MovedPagesGenerator(ts, old_ts):
     for item in request:
         yield {'old':item['title'], 'new':item['move']['new_title'], 'user':item['user']}
 
-
-
-
 def create_timestamp(old=False):
-    now = datetime.datetime.now()
+    now = datetime.datetime.utcnow()
     if old:
-        hour = now.hour-1
-    else:
-        hour = now.hour
-    return '%s-%s-%sT%s:00:00Z' % (now.year, abs_zero(now.month), abs_zero(now.day), abs_zero(hour))
-
-def abs_zero(input):
-    if len(str(input)) == 1:
-        return '0' + str(input)
-    return str(input)
+        now -= datetime.timedelta(hours=1)
+    return now.strftime('%Y-%m-%dT%H:00:00Z')
 
 def main():
     #get page list
@@ -46,10 +35,12 @@ def main():
         user = item['user']
         if new.startswith('Articles for creation/'):
             log = True
-        if old.startswith('Wikipedia talk:Articles for creation/') and new.startswith('Wikipedia talk:'):
-            log = True
-        if old.startswith('Wikipedia:Articles for creation/') and new.startswith('Wikipedia:'):
-            log = True
+        if old.startswith('Wikipedia talk:Articles for creation/'):
+            if new.startswith('Wikipedia talk:') and not new.startswith('Wikipedia talk:Articles for creation/'):
+                log = True
+        if old.startswith('Wikipedia:Articles for creation/'):
+            if new.startswith('Wikipedia:') and not new.startswith('Wikipedia:Articles for creation/'):
+                log = True
         if not log:
             try:
                 print u'Skipping %s --> %s' % (old, new)
@@ -58,14 +49,14 @@ def main():
             continue
         print u'Will log %s --> %s' % (old, new)
         logtext += u'* [[%s]] --> [[%s]] by [[User:%s|]]\n' % (old, new, user)
-    if logtext == u'':
+    if not logtext:
         print u'Nothing was detected, won\'t update the log.'
         return
     p = pywikibot.Page(site, u'Wikipedia:Articles for creation/Wrongly moved submissions')
     current_text = p.get()
     newtext = current_text + '\n' + logtext
     p.put(newtext, u'BOT: Updating log')
-        
-        
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
- Fix bug when pages are moved within the AFC space, which should not be tagged.
- Use built-in datetime manipulation functions. Solves a potential problem when `now.hour == 0`, and is cleaner.
- Use UTC for timestamps instead of local time.
- Removed unused `os` import.
- Some misc cleanup with spacing, etc.
